### PR TITLE
chore(deps): enable auto-rebase for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    rebase-strategy: "auto"
     labels:
       - "dependencies"
       - "npm"
@@ -35,6 +36,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    rebase-strategy: "auto"
     labels:
       - "dependencies"
       - "docker"
@@ -47,6 +49,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    rebase-strategy: "auto"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Summary

Enables automatic rebasing for Dependabot pull requests to reduce the "build pyramid" effect when merging multiple dependency updates.

## Changes

- Add `rebase-strategy: "auto"` to all three package ecosystems:
  - npm dependencies
  - Docker dependencies  
  - GitHub Actions dependencies

## Benefits

- **Reduces manual work**: No more clicking "Update branch" after merging each PR
- **Faster dependency updates**: PRs automatically rebase when main branch changes
- **Works with disabled strict mode**: Complements the branch protection change (strict: false)
- **Safe**: Only handles rebasing, not auto-merging - you still review and approve all changes

## Impact

When merging Dependabot PRs:
- **Before**: Merge PR #1 → manually update PRs #2, #3, #4 → wait for CI → repeat
- **After**: Merge PR #1 → PRs #2, #3, #4 auto-rebase in background → merge when ready

## Testing

Configuration is valid YAML and follows [Dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy).