### PR TITLE
chore(deps): exclude zod from production-dependencies group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,10 @@ updates:
           - "vitest"
           - "tsx"
           - "typescript"
-      # Group production dependencies
+      # Group production dependencies (excluding zod for separate tracking)
       production-dependencies:
         patterns:
           - "@modelcontextprotocol/*"
-          - "zod"
           - "zod-to-json-schema"
 
   # Docker dependencies


### PR DESCRIPTION
## Summary

Removes `zod` from the `production-dependencies` group to allow it to receive separate Dependabot PRs, making version conflicts more visible.

## Context

PR #29 demonstrated the issue: Zod v4 (major version) was grouped with MCP SDK update, but MCP SDK still depends on Zod v3 internally, causing CI failures. By grouping them together, the breaking change wasn't immediately obvious.

## Changes

- Remove `zod` from `production-dependencies` group patterns
- Update comment to clarify exclusion reason

## Benefits

- **Version conflicts become visible**: Major version updates (like v3 → v4) get separate PRs
- **Easier to identify breaking changes**: Can test zod updates independently
- **Safer dependency management**: Won't accidentally merge incompatible versions
- **Still automated**: Zod will still get Dependabot PRs, just not grouped

## Impact

**Before**: Zod updates grouped with MCP SDK → hidden incompatibilities  
**After**: Zod updates in separate PRs → clear when there's a conflict

This allows you to evaluate zod updates independently and avoid forgetting about them later.